### PR TITLE
feat(varci): mark salary-less posts stale

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -16,8 +16,14 @@ Issue title format: [Company Name] - [Job Title] - [Location]
   Include a currency if the work location can be in more places
   than the one in your post title
 
-  IMPORTANT: Posts that do not include a salary or range
-  will receive a 'needs info' label
+  IMPORTANT: The Province of Ontario has a Pay Transparency Act
+  that requires employers to post a compensation range in all
+  public job postings:
+
+  https://www.ontario.ca/laws/statute/s18005#BK6
+
+  As such, posts that do not include a salary or range will
+  receive a 'stale' label and will be closed after 7 days.
 -->
 - $5000/month or negotiable
 - Contract / Full Time

--- a/.varci.yml
+++ b/.varci.yml
@@ -1,11 +1,11 @@
 ruleset:
-  label_needs-info:
-    name: "Label issue as needs info"
+  label_stale:
+    name: "Label issue as stale"
     events: [ issues ]
     when:
       - action = "opened" or action = "edited"
       - not (body contains "Salary Expectation") or not (body contains "## Meta")
-    label: needs info
+    label: stale
 
   label_full-time:
     name: "Label issue as full time"


### PR DESCRIPTION
Given the Ontario [Pay Transparency Act](https://www.ontario.ca/laws/statute/s18005) takes effect in 2019, tweak VarCI to make postings without compensation info as `stale`. This means that after 7 days of inactivity, any posting marked with the `stale` label will get closed (just like regular stale issues).